### PR TITLE
jg/275/Install-pre-commit-hook-for-checking-TS

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx tsc --noEmit


### PR DESCRIPTION
Install pre-commit hook for checking TypeScript to perform a general typing check of the project just before committing. so that these types of errors are detected and thus solved

![image](https://github.com/selsa-inube/personas/assets/87447257/ea659f30-7fbe-40d8-b7c2-5715a3364a4a)
