### PR TITLE
jg/296/Adjust-Assisted-mediaQuery

### DIFF
--- a/src/design/feedback/Assisted/interface.tsx
+++ b/src/design/feedback/Assisted/interface.tsx
@@ -50,7 +50,7 @@ function AssistedUI(props: AssistedUIProps) {
     lastStep,
   } = props;
 
-  const smallScreen = useMediaQuery("(max-width: 560px)");
+  const smallScreen = useMediaQuery("(max-width: 744px)");
 
   return (
     <StyledAssistedContainer smallScreen={smallScreen}>


### PR DESCRIPTION
Changed use media query so that assisted title does not scale on tablet screens based on width designs.

![image](https://github.com/selsa-inube/personas/assets/87447257/723d66d4-3e84-4248-88a4-9220844ffa8a)
